### PR TITLE
Fixed CommandCommand (and the same problem in LocalOCServer)

### DIFF
--- a/node/src/main/java/de/obsidiancloud/node/command/CommandCommand.java
+++ b/node/src/main/java/de/obsidiancloud/node/command/CommandCommand.java
@@ -6,7 +6,6 @@ import de.obsidiancloud.common.command.Command;
 import de.obsidiancloud.common.command.CommandExecutor;
 import de.obsidiancloud.node.ObsidianCloudNode;
 import de.obsidiancloud.node.local.LocalOCServer;
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.Arrays;
 import org.jetbrains.annotations.NotNull;
@@ -37,9 +36,8 @@ public class CommandCommand extends Command {
         Process process = localServer.getProcess();
         try {
             if (process != null && process.isAlive()) {
-                try (BufferedWriter writer = process.outputWriter()) {
-                    writer.write(command + "\n");
-                }
+                process.outputWriter().write(command + "\n");
+                process.outputWriter().flush();
             } else {
                 ObsidianCloudNode.getLogger().warning("Cannot send command, the server is not running.");
             }

--- a/node/src/main/java/de/obsidiancloud/node/local/LocalOCServer.java
+++ b/node/src/main/java/de/obsidiancloud/node/local/LocalOCServer.java
@@ -12,7 +12,6 @@ import de.obsidiancloud.node.ObsidianCloudNode;
 import de.obsidiancloud.node.util.Flags;
 import de.obsidiancloud.node.util.NetworkUtil;
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -103,10 +102,8 @@ public class LocalOCServer extends OCServer {
                 if (platform == null) {
                     process.destroy();
                 } else {
-                    try (BufferedWriter writer = process.outputWriter()) {
-                        writer.write(getData().platform().stopCommand() + "\n");
-                        writer.flush();
-                    }
+                    process.outputWriter().write(getData().platform().stopCommand() + "\n");
+                    process.outputWriter().flush();
                 }
             }
         } catch (Throwable exception) {
@@ -365,6 +362,7 @@ public class LocalOCServer extends OCServer {
     private void stopped() {
         ObsidianCloudNode.getLogger().info("Server " + getName() + " stopped");
         NetworkUtil.unblockPort(port);
+        port = -1;
         ServerPortChangedPacket packet = new ServerPortChangedPacket();
         packet.setName(getName());
         packet.setPort(-1);


### PR DESCRIPTION
The output writer of processes no longer gets closed